### PR TITLE
Fix Podfile format

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,5 @@ target 'RealmConverter' do
     pod 'PathKit', '~> 0.6.0' # 0.7+ requires swift 3
     pod 'CSwiftV'
     pod 'TGSpreadsheetWriter'
-
-    target 'RealmConverterTests'
 end
+


### PR DESCRIPTION
Current `Podfile` will result in this warning:

```
[!] Invalid `Podfile` file: no block given (yield). Updating CocoaPods might fix the issue.
```
