### PR TITLE
Initialize DataExporter with Realm instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ as well; and all classes on the Objective-C side are pre-fixed with `RLM`.
 let realmFilePath = '' // Absolute file path to my Realm file
 let outputFolderPath = '' // Absolute path to the folder which will hold the CSV files
 
-let csvDataExporter = CSVDataExporter(realmFilePath: realmFilePath)
+let csvDataExporter = try! CSVDataExporter(realmFilePath: realmFilePath)
 try! csvDataExporter.exportToFolderAtPath(outputFolderPath)
 ```
 

--- a/RealmConverter.xcodeproj/project.pbxproj
+++ b/RealmConverter.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0810;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Realm;
 				TargetAttributes = {
 					2213C6F51C50BE1000902618 = {

--- a/RealmConverter.xcodeproj/xcshareddata/xcschemes/RealmConverter.xcscheme
+++ b/RealmConverter.xcodeproj/xcshareddata/xcschemes/RealmConverter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RealmConverter/Exporter/CSVDataExporter.swift
+++ b/RealmConverter/Exporter/CSVDataExporter.swift
@@ -51,14 +51,7 @@ public class CSVDataExporter: DataExporter {
      
      - parameter outputFolderpath: An absolute path to a folder where the transformed files will be saved
      */
-    public override func exportToFolderAtPath(outputFolderPath: String) throws {
-        
-        let realmConfiguration = RLMRealmConfiguration.defaultConfiguration()
-        realmConfiguration.fileURL = NSURL(fileURLWithPath: realmFilePath)
-        realmConfiguration.dynamic = true
-        
-        let realm = try RLMRealm(configuration: realmConfiguration)
-        
+    public override func exportToFolderAtPath(outputFolderPath: String) throws {        
         // Write out a .csv file for each object in the Realm
         for objectSchema in realm.schema.objectSchema {
             let filePath = Path(outputFolderPath) + Path("\(objectSchema.className).csv")

--- a/RealmConverter/Exporter/DataExporter.swift
+++ b/RealmConverter/Exporter/DataExporter.swift
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Foundation
+import Realm
 
 /**
  An abstract class manages the common logic for 
@@ -25,18 +26,41 @@ import Foundation
 */
 public class DataExporter: NSObject {
     
-    public var realmFilePath = ""
+    public let realm: RLMRealm
     
     /**
      Create a new instance of the exporter object
      
      - parameter realmFilePath: An absolute path to the Realm file to be exported
      */
-    @objc(initWithRealmFileAtPath:)
-    public init (realmFilePath: String) {
-        self.realmFilePath = realmFilePath
+    @objc(initWithRealmFileAtPath:error:)
+    public convenience init(realmFilePath: String) throws {
+        let configuration = RLMRealmConfiguration.defaultConfiguration()
+        configuration.fileURL = NSURL(fileURLWithPath: realmFilePath)
+        configuration.dynamic = true
+
+        let realm = try RLMRealm(configuration: configuration)
+
+        self.init(realm: realm)
     }
-    
+
+    /**
+     Create a new instance of the exporter object
+
+     - parameter realm: An instance of Realm to be exported
+     */
+    @objc(initWithRealm:)
+    public init(realm: RLMRealm) {
+        if realm.configuration.dynamic {
+            self.realm = realm
+        } else {
+            let configuration = realm.configuration
+            configuration.dynamic = true
+
+            self.realm = try! RLMRealm(configuration: configuration)
+        }
+    }
+
     /**
      Exports all of the contents of the provided Realm file to
      the designated output folder.
@@ -47,4 +71,5 @@ public class DataExporter: NSObject {
     public func exportToFolderAtPath(outputFolderPath: String) throws {
         fatalError("Cannot call export() from DataExporter base class")
     }
+
 }

--- a/RealmConverterTests/Objective-C/RLMRealmConverter+Exporter.m
+++ b/RealmConverterTests/Objective-C/RLMRealmConverter+Exporter.m
@@ -74,7 +74,9 @@ NSString * const kRLMTestRealmFileName = @"dogs.realm";
     XCTAssertNotNil(realmFilePath);
     
     // Test the exporter and ensure it didn't generate any errors
-    RLMCSVDataExporter *exporter = [[RLMCSVDataExporter alloc] initWithRealmFileAtPath:realmFilePath];
+    RLMCSVDataExporter *exporter = [[RLMCSVDataExporter alloc] initWithRealmFileAtPath:realmFilePath error:&error];
+    XCTAssertNil(error);
+
     [exporter exportToFolderAtPath:self.outputTempFolderPath withError:&error];
     XCTAssertNil(error);
     

--- a/RealmConverterTests/Swift/CSVExportTests.swift
+++ b/RealmConverterTests/Swift/CSVExportTests.swift
@@ -60,7 +60,7 @@ class CSVExportTests: XCTestCase {
     }
     
     func exportToCSVAndCheckResults(realmPath: String, outputDirectoryPath: String) throws {
-        let exporter = CSVDataExporter(realmFilePath: realmPath)
+        let exporter = try CSVDataExporter(realmFilePath: realmPath)
         
         try exporter.exportToFolderAtPath(outputDirectoryPath)
         


### PR DESCRIPTION
Currently there is no way to export synced Realms as they are stored in a cached location and their paths are not exposed via public API. This PR allows `DataExporter` to be initialized with `Realm` instance as well as with file path.

This is an API-breaking change, refs https://github.com/realm/realm-browser-osx/issues/254.