### PR TITLE
Fix Bool property type detection when generating Realm classes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - CSwiftV (0.0.5)
   - PathKit (0.6.0)
-  - Realm (2.1.2):
-    - Realm/Headers (= 2.1.2)
-  - Realm/Headers (2.1.2)
-  - SSZipArchive (1.6.2)
+  - Realm (2.4.2):
+    - Realm/Headers (= 2.4.2)
+  - Realm/Headers (2.4.2)
+  - SSZipArchive (1.7)
   - TGSpreadsheetWriter (1.0.2):
     - SSZipArchive
 
@@ -17,8 +17,8 @@ DEPENDENCIES:
 SPEC CHECKSUMS:
   CSwiftV: 2560532e2e5b04d95c36b0f49a8dc745071fa525
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
-  Realm: efe855f4d977c8ce5a82d3116d9f1ff155a6550c
-  SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
+  Realm: d27b758e12d62a3371879a065d4c40aa212c5a54
+  SSZipArchive: 63f8e11cfcc33e03e4cd666b4359ea8bd6facd0c
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 
 PODFILE CHECKSUM: 733f9f3de0ecffd30d11ecc35b276157c484b381

--- a/RealmConverter.podspec
+++ b/RealmConverter.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   s.dependency 'Realm'
   s.dependency 'PathKit', '~> 0.6.0'
   s.dependency 'CSwiftV'
+  s.dependency 'SSZipArchive', '~> 1.6.2'
   s.dependency 'TGSpreadsheetWriter'
 end

--- a/RealmConverter/Importer/DataImporter.swift
+++ b/RealmConverter/Importer/DataImporter.swift
@@ -92,6 +92,11 @@ public class DataImporter: NSObject {
                     size = sizeof(Double)
                     alignment = UInt8(log2(Double(size)))
                     encode = "d"
+                case .Bool:
+                    type = objc_property_attribute_t(name: "T".cStringUsingEncoding(NSUTF8StringEncoding), value: "B".cStringUsingEncoding(NSUTF8StringEncoding))
+                    size = sizeof(Bool)
+                    alignment = UInt8(log2(Double(size)))
+                    encode = "B"
                 default:
                     type = objc_property_attribute_t(name: "T".cStringUsingEncoding(NSUTF8StringEncoding), value: "@\"NSString\"".cStringUsingEncoding(NSUTF8StringEncoding))
                     size = sizeof(NSObject)


### PR DESCRIPTION
The issue with `Boolean`s detection is still there. Import schema is generated correctly while Realm schema generation doesn't handle `Boolean`  properties.

Fixes: https://github.com/realm/realm-browser-osx/issues/252

/cc @jpsim, @TimOliver 