### PR TITLE
Always escape exported values to avoid corruption

### DIFF
--- a/RealmConverter/Exporter/CSVDataExporter.swift
+++ b/RealmConverter/Exporter/CSVDataExporter.swift
@@ -106,10 +106,8 @@ open class CSVDataExporter: DataExporter {
             return valueByEscapingQuotes(
                 value.replacingOccurrences(of: escapeQuotes, with: escapeQuotes + escapeQuotes)
             )
-        } else if value.range(of: " ") != nil || value.range(of: delimiter) != nil {
-            return valueByEscapingQuotes(value)
         }
-        return value
+        return valueByEscapingQuotes(value)
     }
     
     fileprivate func serializedObject(_ object: RLMObject, realm: RLMRealm) -> String {


### PR DESCRIPTION
This addresses #50 by forcing all values to be escaped. This is an
admittedly brute-force solution which should be superceded by a
reliable CSV Export library in the future.