### PR TITLE
Handle RLMPropertyType.UUID in the ImportObjectSchema class

### DIFF
--- a/RealmConverter/Schema/ImportObjectSchema.swift
+++ b/RealmConverter/Schema/ImportObjectSchema.swift
@@ -106,6 +106,8 @@ extension RLMPropertyType: CustomStringConvertible, CustomDebugStringConvertible
             return "objectID"
         case .decimal128:
             return "decimal128"
+        case .UUID:
+            return "uuid"
         }
     }
     


### PR DESCRIPTION
`RLMPropertyType.UUID` was added for https://github.com/realm/realm-swift/pull/6958. The compiler throws an error now because this switch statement is no longer exhaustive. Handling the new `UUID` type makes the error go away.